### PR TITLE
refactor: restructure the app code, allowing better maintainability

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,10 +1,10 @@
 import json
 
 from typing import TypedDict, TypeVar
-from utils.logging import Color, log
+from app.logging import Color, log
 
 
-class _HotkeyStyleConfig(TypedDict):
+class HotkeyStyleConfig(TypedDict):
     is_horizontal: bool
     chin_color: str
     shadow_color: str
@@ -19,13 +19,13 @@ class _HotkeyStyleConfig(TypedDict):
 
 class Config(TypedDict):
     port: int
-    hotkey_style: _HotkeyStyleConfig
+    hotkey_style: HotkeyStyleConfig
     hotkeys: list[str]
 
 
 _DEFAULT_CONFIG: Config = Config(
     port=8000,
-    hotkey_style=_HotkeyStyleConfig(
+    hotkey_style=HotkeyStyleConfig(
         is_horizontal=True,
         chin_color="#d9d9d9",
         shadow_color="#adb5bd",
@@ -66,28 +66,34 @@ _DEFAULT_CONFIG: Config = Config(
 )
 
 
-def _load_config(filename: str) -> Config:
+_CONFIG_FILENAME: str = "config.json"
+
+config: Config
+
+
+def load() -> None:
     # load the config from the specified file
-    config = {}
+    _config = {}
     try:
-        config = json.load(open(filename, "r"))
+        _config = json.load(open(_CONFIG_FILENAME, "r"))
     except json.decoder.JSONDecodeError as e:
         log(f"Failed to parse the config file: {e}.", Color.RED)
         log(
-            "Consider deleting the config.json file to create a new default config.",
+            "You can delete the config.json file to create a new default config.",
             Color.YELLOW,
         )
         raise SystemExit
     except FileNotFoundError:
-        log("No config.json found, creating a default config.", Color.YELLOW)
+        log("No config.json found, creating a default config.", Color.LYELLOW)
 
     # ensure default values for all unset properties recursively (sub-dicts)
-    _set_defaults_recursive(config, _DEFAULT_CONFIG)
+    _set_defaults_recursive(_config, _DEFAULT_CONFIG)
 
     # save the config in order to add properties missing in the file with their default values
-    json.dump(config, open(filename, "w"), indent=4)
+    json.dump(_config, open(_CONFIG_FILENAME, "w"), indent=4)
 
-    return Config(Config(**config))
+    global config
+    config = Config(Config(**_config))
 
 
 T = TypeVar("T", bound=dict)
@@ -102,6 +108,3 @@ def _set_defaults_recursive(dictionary: T, default: T) -> None:
         if isinstance(value, dict):
             dictionary.setdefault(key, {})
             _set_defaults_recursive(dictionary[key], value)
-
-
-config: Config = _load_config("config.json")

--- a/app/handlers/hotkey_handler.py
+++ b/app/handlers/hotkey_handler.py
@@ -1,0 +1,37 @@
+import asyncio
+import keyboard
+import app.config
+import app.handlers.web_handler
+
+from typing import TypedDict
+from datetime import datetime
+from app.logging import Color, log, printc
+
+
+class HotkeyEvent(TypedDict):
+    hotkey: str
+    timestamp: datetime
+
+
+def register_hotkey_hooks(loop: asyncio.AbstractEventLoop) -> None:
+    # register all hotkeys defined in the config
+    for hotkey in app.config.config["hotkeys"]:
+        keyboard.add_hotkey(
+            hotkey,
+            lambda h=hotkey: asyncio.run_coroutine_threadsafe(
+                _hotkey_callback(HotkeyEvent(hotkey=h, timestamp=datetime.utcnow())),
+                loop,
+            ),  # type: ignore
+        )
+
+    log(f"Registered {len(app.config.config['hotkeys'])} hotkeys", Color.GREEN)
+
+
+# the callback called via asyncio.run_coroutine_threadsafe, sending the event to connected websockets
+async def _hotkey_callback(event: HotkeyEvent) -> None:
+    log("Detected hotkey ", Color.LCYAN, nl=False)
+    printc(event["hotkey"])
+
+    # add the hotkey event to all queues
+    for queue in app.handlers.web_handler.ws_queues:
+        queue.put_nowait(event)

--- a/app/handlers/web_handler.py
+++ b/app/handlers/web_handler.py
@@ -1,0 +1,37 @@
+import asyncio
+import app.config
+
+from quart import Blueprint, render_template, websocket
+from app.logging import Color, log
+
+
+blueprint: Blueprint = Blueprint("web_handler", __name__)
+ws_queues: set[asyncio.Queue] = set()
+
+
+@blueprint.get("/")
+async def get():
+    # serve the visualizer webpage
+    return await render_template(
+        "visualizer.html",
+        style_config=app.config.config["hotkey_style"],
+        port=app.config.config["port"],
+    )
+
+
+@blueprint.websocket("/")
+async def ws():
+    # accept the websocket connection and add a new payload queue
+    await websocket.accept()
+    queue = asyncio.Queue()
+    ws_queues.add(queue)
+
+    log("Websocket connection established", Color.GREEN)
+
+    # handle the lifetime of the websocket connection
+    try:
+        while True:
+            await websocket.send_json(await queue.get())
+    finally:
+        ws_queues.remove(queue)
+        log("Websocket disconnected", Color.RED)

--- a/app/logging.py
+++ b/app/logging.py
@@ -1,6 +1,7 @@
 from enum import IntEnum
 from datetime import datetime
 
+
 # console color codes
 class Color(IntEnum):
     BLACK = 30
@@ -25,9 +26,11 @@ class Color(IntEnum):
 
     def __repr__(self) -> str:
         return f"\x1b[{self.value}m"
-    
+
+
 def printc(msg: str, color: Color = Color.RESET, nl: bool = True) -> None:
     print(f"{color!r}{msg}{Color.RESET!r}", end="\n" if nl else "")
+
 
 def log(msg: str, color: Color = Color.RESET, nl: bool = True) -> None:
     printc(f"[{datetime.now().strftime('%H:%M:%S')}] ", Color.GRAY, nl=False)

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,48 @@
+import sys
+import json
+import os.path
+import requests
+
+from app.logging import Color, log
+
+
+VERSION_TXT: str = os.path.join(getattr(sys, "_MEIPASS", ""), "version.txt")  # type: ignore
+LATEST_RELEASE_URL: str = (
+    "https://github.com/minisbett/epiclonvisualizer/releases/latest"
+)
+
+
+async def run_update_check() -> None:
+    # run an update check, but ignore them on local environments (not a PyInstaller executable)
+    if not _is_pyinstaller_executable():
+        log("Running locally, skipping update checks.")
+        return
+
+    log("Checking for updates...")
+
+    # get the latest release
+    if not (latest := await _get_latest_release()):
+        return
+
+    log(f"Latest version: {latest}")
+
+    # compare the fetched tag name with the version.txt file bundled in the data-files (MEI folder)
+    with open(VERSION_TXT, "r") as file:  # type: ignore
+        if (version := file.read()) != latest:
+            log(f"A newer version is available ({version} -> {latest})")
+            log(f"You can download it here: {LATEST_RELEASE_URL}")
+        else:
+            log("You are using the latest version.")
+
+
+async def _get_latest_release() -> str | None:
+    try:
+        # get the latest release tag from the github api
+        response = requests.get(f"https://api.{LATEST_RELEASE_URL[8:]}")
+        return json.loads(response.content)["tag_name"]
+    except Exception as e:
+        log(f"Update check failed: {e}", Color.RED)
+
+
+def _is_pyinstaller_executable() -> bool:
+    return getattr(sys, "frozen", False)

--- a/main.py
+++ b/main.py
@@ -1,124 +1,40 @@
-import sys
-import os.path
-import json
 import asyncio
-import keyboard
-import requests
 import hypercorn.asyncio
 import hypercorn.config
+import app.utils
+import app.config
+import app.handlers.web_handler
+import app.handlers.hotkey_handler
 
-from datetime import datetime
-from quart import Quart, render_template, websocket, request
-from objects.hotkey_event import HotkeyEvent
-from utils.logging import Color, log, printc
-from config import config
-
-
-GITHUB_REPOSITORY: str = "minisbett/epiclonvisualizer"
-
-app: Quart = Quart(__name__)
-hotkey_events_ws_queues: set[asyncio.Queue[HotkeyEvent]] = set()
+from quart import Quart
+from app.logging import Color, log
 
 
-def register_hotkey_hooks(loop: asyncio.AbstractEventLoop) -> None:
-    # the callback called via asyncio.run_coroutine_threadsafe, sending the event to connected websockets
-    async def hotkey_callback(event: HotkeyEvent) -> None:
-        log("Detected hotkey ", Color.LCYAN, nl=False)
-        printc(event["hotkey"])
-
-        # add the hotkey event to all queues
-        for queue in hotkey_events_ws_queues:
-            queue.put_nowait(event)
-
-    # register all hotkeys defined in the config
-    for hotkey in config["hotkeys"]:
-        keyboard.add_hotkey(
-            hotkey,
-            lambda h=hotkey: asyncio.run_coroutine_threadsafe(
-                hotkey_callback(HotkeyEvent(hotkey=h, timestamp=datetime.utcnow())),
-                loop,
-            ),  # type: ignore
-        )
-
-    log(f"Registered {len(config['hotkeys'])} hotkeys", Color.GREEN)
+quart: Quart = Quart(__name__)
+quart.register_blueprint(app.handlers.web_handler.blueprint)
 
 
-@app.get("/")
-async def get():
-    # serve the visualizer webpage
-    return await render_template(
-        "visualizer.html",
-        style_config=config["hotkey_style"],
-        port=config["port"],
-    )
-
-
-@app.websocket("/")
-async def ws():
-    # accept the websocket connection and add a new event queue
-    await websocket.accept()
-    queue = asyncio.Queue()
-    hotkey_events_ws_queues.add(queue)
-
-    log("Websocket connection established", Color.GREEN)
-
-    # handle the lifetime of the websocket connection
-    try:
-        while True:
-            event = await queue.get()
-            await websocket.send_json(event)
-    finally:
-        hotkey_events_ws_queues.remove(queue)
-        log("Websocket disconnected", Color.RED)
-
-
-@app.before_serving
+@quart.before_serving
 async def before_serving():
-    async with app.test_request_context(""):
+    async with quart.test_request_context(""):
         log(
-            f"Serving app @ http://localhost:{config['port']}/",
+            f"Serving app @ http://localhost:{app.config.config['port']}/",
             Color.MAGENTA,
         )
 
 
 async def main() -> None:
+    # load the config and run the app
+    app.config.load()
+
     # register all configured hotkey hooks
-    register_hotkey_hooks(asyncio.get_running_loop())
+    app.handlers.hotkey_handler.register_hotkey_hooks(asyncio.get_running_loop())
 
     # setup hypercorn
     hconf = hypercorn.config.Config()
-    hconf.bind = f"localhost:{config['port']}"
+    hconf.bind = f"localhost:{app.config.config['port']}"
     hconf.errorlog = None
-    await hypercorn.asyncio.serve(app, hconf)
+    await hypercorn.asyncio.serve(quart, hconf)
 
 
-def update_check() -> None:
-    # get the latest release tag from the github api
-    url = f"https://api.github.com/repos/{GITHUB_REPOSITORY}/releases/latest"
-    newest_version = json.loads(requests.get(url).content)["tag_name"]
-    log(f"Latest version: {newest_version}")
-    
-    # compare the fetched tag name with the version.txt file bundled in the data-files (MEI folder)
-    with open(os.path.join(sys._MEIPASS, "version.txt"), "r") as file:  # type: ignore
-        version = file.read()
-        if newest_version == version:
-            log("You are using the latest version.")
-        else:
-            log(f"A newer version is available ({version} -> {newest_version})")
-            log(f"You can download it here: https://github.com/{GITHUB_REPOSITORY}/releases/latest")
-
-
-# do an update check and run the app
-if __name__ == "__main__":
-    # ignore update checks on local executions (as opposed to PyInstaller executables)
-    if not getattr(sys, "frozen", False):
-        log("Running locally, skipping update checks.")
-    else:
-        try:
-            log("Checking for updates...")
-            update_check()
-        except Exception as e:
-            log(f"Could not check for updates: {e}", Color.RED)
-            pass
-
-    asyncio.run(main())
+asyncio.run(main())

--- a/objects/hotkey_event.py
+++ b/objects/hotkey_event.py
@@ -1,7 +1,0 @@
-from typing import TypedDict
-from datetime import datetime
-
-
-class HotkeyEvent(TypedDict):
-    hotkey: str
-    timestamp: datetime


### PR DESCRIPTION
The following changes have been done:
1. all code, except for `main.py`, is now contained inside an `app` folder
2. all quart routes have been migrated into a blueprint, with a dedicated file in `app/handlers/web_handler.py`
3. the hotkey handling has been migrated to `app/handlers/hotkey_handler.py`
4. the update checker has been migrated to `/app/utils.py`