### PR TITLE
fix: make logging support ANSI colors on conhost-based consoles

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -79,14 +79,13 @@ def load() -> None:
     try:
         _config = json.load(open(_CONFIG_FILENAME, "r"))
     except json.decoder.JSONDecodeError as e:
-        log(f"Failed to parse the config file: {e}.", Color.RED)
+        log(f"{Color.RED}Failed to parse the config file: {e}.")
         log(
-            "You can delete the config.json file to create a new default config.",
-            Color.YELLOW,
+            f"{Color.LYELLOW}You can delete the config.json file to create a new default config."
         )
         raise SystemExit
     except FileNotFoundError:
-        log("No config.json found, creating a default config.", Color.LYELLOW)
+        log(f"{Color.LYELLOW}No config.json found, creating a default config.")
 
     # ensure default values for all unset properties recursively (sub-dicts)
     _set_defaults_recursive(_config, _DEFAULT_CONFIG)

--- a/app/handlers/hotkey_handler.py
+++ b/app/handlers/hotkey_handler.py
@@ -5,7 +5,7 @@ import app.handlers.web_handler
 
 from typing import TypedDict
 from datetime import datetime
-from app.logging import Color, log, printc
+from app.logging import Color, log
 
 
 class HotkeyEvent(TypedDict):
@@ -24,13 +24,12 @@ def register_hotkey_hooks(loop: asyncio.AbstractEventLoop) -> None:
             ),  # type: ignore
         )
 
-    log(f"Registered {len(app.config.config['hotkeys'])} hotkeys", Color.GREEN)
+    log(f"{Color.GREEN}Registered {len(app.config.config['hotkeys'])} hotkeys")
 
 
 # the callback called via asyncio.run_coroutine_threadsafe, sending the event to connected websockets
 async def _hotkey_callback(event: HotkeyEvent) -> None:
-    log("Detected hotkey ", Color.LCYAN, nl=False)
-    printc(event["hotkey"])
+    log(f"{Color.LCYAN}Detected hotkey {Color.RESET}{event['hotkey']}")
 
     # add the hotkey event to all queues
     for queue in app.handlers.web_handler.ws_queues:

--- a/app/handlers/web_handler.py
+++ b/app/handlers/web_handler.py
@@ -26,7 +26,7 @@ async def ws():
     queue = asyncio.Queue()
     ws_queues.add(queue)
 
-    log("Websocket connection established", Color.GREEN)
+    log(f"{Color.GREEN}Websocket connection established")
 
     # handle the lifetime of the websocket connection
     try:
@@ -34,4 +34,4 @@ async def ws():
             await websocket.send_json(await queue.get())
     finally:
         ws_queues.remove(queue)
-        log("Websocket disconnected", Color.RED)
+        log(f"{Color.RED}Websocket disconnected")

--- a/app/logging.py
+++ b/app/logging.py
@@ -1,3 +1,5 @@
+import colorama
+
 from enum import IntEnum
 from datetime import datetime
 
@@ -24,14 +26,15 @@ class Color(IntEnum):
 
     RESET = 0
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         return f"\x1b[{self.value}m"
+    
+
+def initialize() -> None:
+    # colorama provides ANSI support for coloring in the console
+    colorama.just_fix_windows_console()
 
 
-def printc(msg: str, color: Color = Color.RESET, nl: bool = True) -> None:
-    print(f"{color!r}{msg}{Color.RESET!r}", end="\n" if nl else "")
-
-
-def log(msg: str, color: Color = Color.RESET, nl: bool = True) -> None:
-    printc(f"[{datetime.now().strftime('%H:%M:%S')}] ", Color.GRAY, nl=False)
-    printc(msg, color, nl)
+def log(msg: str) -> None:
+    # prints the specified message with a timestamp
+    print(f"{Color.GRAY}[{datetime.now().strftime('%H:%M:%S')}] {Color.RESET}{msg}{Color.RESET}")

--- a/app/utils.py
+++ b/app/utils.py
@@ -41,7 +41,7 @@ async def _get_latest_release() -> str | None:
         response = requests.get(f"https://api.{LATEST_RELEASE_URL[8:]}")
         return json.loads(response.content)["tag_name"]
     except Exception as e:
-        log(f"Update check failed: {e}", Color.RED)
+        log(f"{Color.RED}Update check failed: {e}")
 
 
 def _is_pyinstaller_executable() -> bool:

--- a/ext/requirements.txt
+++ b/ext/requirements.txt
@@ -1,3 +1,4 @@
 quart==0.19.4
 keyboard==0.13.5
 requests==2.31.0
+colorama==0.4.6

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import app.utils
 import app.config
 import app.handlers.web_handler
 import app.handlers.hotkey_handler
+import app.logging
 
 from quart import Quart
 from app.logging import Color, log
@@ -18,12 +19,14 @@ quart.register_blueprint(app.handlers.web_handler.blueprint)
 async def before_serving():
     async with quart.test_request_context(""):
         log(
-            f"Serving app @ http://localhost:{app.config.config['port']}/",
-            Color.MAGENTA,
+            f"{Color.MAGENTA}Serving app @ http://localhost:{app.config.config['port']}/"
         )
 
 
 async def main() -> None:
+    # setup logging
+    app.logging.initialize()
+    
     # load the config and run the app
     app.config.load()
 


### PR DESCRIPTION
Windows' conhost based consoles do not support ANSI sequences for coloring, the terminal does. This adds support through the package colorama.