### PR TITLE
feat: option to only detect hotkeys inside the osu! editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ On first startup, the application creates a `config.json` file in the same direc
 
 ### Configuration options
 
-#### Server Configuration
+- **port**: Specifies the port number on which the server runs. Default is 8000.
 
-- **Port**: Specifies the port number on which the server runs. Default is 8000.
+- **osu_editor_only**: If true, hotkeys are only detected if the currently active window is the osu! editor.
 
 #### Hotkey Style
 

--- a/app/config.py
+++ b/app/config.py
@@ -19,12 +19,14 @@ class HotkeyStyleConfig(TypedDict):
 
 class Config(TypedDict):
     port: int
+    osu_editor_only: bool
     hotkey_style: HotkeyStyleConfig
     hotkeys: list[str]
 
 
 _DEFAULT_CONFIG: Config = Config(
     port=8000,
+    osu_editor_only=False,
     hotkey_style=HotkeyStyleConfig(
         is_horizontal=True,
         chin_color="#d9d9d9",

--- a/app/handlers/hotkey_handler.py
+++ b/app/handlers/hotkey_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import keyboard
+import app.utils
 import app.config
 import app.handlers.web_handler
 
@@ -29,6 +30,13 @@ def register_hotkey_hooks(loop: asyncio.AbstractEventLoop) -> None:
 
 # the callback called via asyncio.run_coroutine_threadsafe, sending the event to connected websockets
 async def _hotkey_callback(event: HotkeyEvent) -> None:
+    # if the osu editor only option is enabled, perform the check
+    if (
+        app.config.config["osu_editor_only"]
+        and not app.utils.is_active_window_osu_editor()
+    ):
+        return
+
     log(f"{Color.LCYAN}Detected hotkey {Color.RESET}{event['hotkey']}")
 
     # add the hotkey event to all queues

--- a/app/utils.py
+++ b/app/utils.py
@@ -2,6 +2,7 @@ import sys
 import json
 import os.path
 import requests
+import pyautogui
 
 from app.logging import Color, log
 
@@ -40,6 +41,11 @@ async def _get_latest_release() -> str | None:
         return json.loads(response.content)["tag_name"]
     except Exception as e:
         log(f"{Color.RED}Update check failed: {e}")
+
+
+def is_active_window_osu_editor() -> bool:
+    title: str = pyautogui.getActiveWindowTitle()  # type: ignore
+    return title.startswith("osu!  -") and title.endswith(".osu")
 
 
 def _is_pyinstaller_executable() -> bool:

--- a/ext/requirements.txt
+++ b/ext/requirements.txt
@@ -2,3 +2,4 @@ quart==0.19.4
 keyboard==0.13.5
 requests==2.31.0
 colorama==0.4.6
+pyautogui==0.9.54


### PR DESCRIPTION
Uses pyautogui to check whether the title of the currently active window starts with `osu!  -` and ends with `.osu`.